### PR TITLE
Add custom tasks per server or infrastructure

### DIFF
--- a/after_leapp_install.yml
+++ b/after_leapp_install.yml
@@ -1,0 +1,17 @@
+---
+# Everything you need to do before starting the upgrade
+# to customize repository or dnf for example
+
+# Check if a custom tasks file exist
+- name: "Does {{ playbook_dir }}/custom_tasks/after_leap_install_custom_tasks.yml file exist ?"
+  stat:
+    path: "{{ playbook_dir }}/custom_tasks/after_leap_install_custom_tasks.yml"
+  register: after_leap_install
+  delegate_to: localhost
+
+# Play this file's tasks if it exists
+- name: "{{ playbook_dir }}/custom_tasks/after_leap_install_custom_tasks.yml exists"
+  include_tasks: "{{ playbook_dir }}/custom_tasks/after_leap_install_custom_tasks.yml"
+  when:
+    - after_leap_install is defined
+    - after_leap_install.stat.exists

--- a/after_upgrade.yml
+++ b/after_upgrade.yml
@@ -1,0 +1,34 @@
+---
+# Everything you need to do after the upgrade
+# eg: sending a notification on mattermost, slack or any other system,
+# installing packages....
+
+# Check if a custom tasks file exist
+- name: "Does {{ playbook_dir }}/custom_tasks/after_upgrade_custom_tasks.yml file exist ?"
+  stat:
+    path: "{{ playbook_dir }}/custom_tasks/after_upgrade_custom_tasks.yml"
+  register: global_custom_after
+  delegate_to: localhost
+
+# Play this file's tasks if it exists
+- name: "{{ playbook_dir }}/custom_tasks/after_upgrade_custom_tasks.yml exists"
+  include_tasks: "{{ playbook_dir }}/custom_tasks/after_upgrade_custom_tasks.yml"
+  when:
+    - global_custom_after is defined
+    - global_custom_after.stat.exists
+
+# Everything to be done per computer basis
+# like starting services, installing specifics packages etc.
+# Check if a custom tasks file exist for this hostname
+- name: "Does {{ playbook_dir }}/custom_tasks/after_upgrade_{{ inventory_hostname_short }}_custom_tasks.yml file exist ?"
+  stat:
+    path: "{{ playbook_dir }}/custom_tasks/after_upgrade_{{ inventory_hostname_short }}_custom_tasks.yml"
+  register: custom_after
+  delegate_to: localhost
+
+# Play this file's tasks if it exists
+- name: "{{ playbook_dir }}/custom_tasks/after_upgrade_{{ inventory_hostname_short }}_custom_tasks.yml exists"
+  include_tasks: "{{ playbook_dir }}/custom_tasks/after_upgrade_{{ inventory_hostname_short }}_custom_tasks.yml"
+  when:
+    - custom_after is defined
+    - custom_after.stat.exists

--- a/before_upgrade.yml
+++ b/before_upgrade.yml
@@ -1,0 +1,34 @@
+---
+# Everything you need to do before starting the upgrade
+# eg: sending a notification on mattermost, slack or any other system,
+# removing packages....
+
+# Check if a custom tasks file exist
+- name: "Does {{ playbook_dir }}/custom_tasks/before_upgrade_custom_tasks.yml file exist ?"
+  stat:
+    path: "{{ playbook_dir }}/custom_tasks/before_upgrade_custom_tasks.yml"
+  register: global_custom_before
+  delegate_to: localhost
+
+# Play this file's tasks if it exists
+- name: "{{ playbook_dir }}/custom_tasks/before_upgrade_custom_tasks.yml exists"
+  include_tasks: "{{ playbook_dir }}/custom_tasks/before_upgrade_custom_tasks.yml"
+  when:
+    - global_custom_before is defined
+    - global_custom_before.stat.exists
+
+# Everything to be done per computer basis
+# like stopping services, removing specifics packages etc.
+# Check if a custom tasks file exist for this hostname
+- name: "Does {{ playbook_dir }}/custom_tasks/before_upgrade_{{ inventory_hostname_short }}_custom_tasks.yml file exist ?"
+  stat:
+    path: "{{ playbook_dir }}/custom_tasks/before_upgrade_{{ inventory_hostname_short }}_custom_tasks.yml"
+  register: custom_before
+  delegate_to: localhost
+
+# Play this file's tasks if it exists
+- name: "{{ playbook_dir }}/custom_tasks/before_upgrade_{{ inventory_hostname_short }}_custom_tasks.yml exists"
+  include_tasks: "{{ playbook_dir }}/custom_tasks/before_upgrade_{{ inventory_hostname_short }}_custom_tasks.yml"
+  when:
+    - custom_before is defined
+    - custom_before.stat.exists

--- a/centos7-to-rocky-elevate.yml
+++ b/centos7-to-rocky-elevate.yml
@@ -4,77 +4,86 @@
   gather_facts: false
   become: true
   vars:
-  
+
   tasks:
-  - name: quick check if all hosts was specified with no limit
-    ansible.builtin.assert:
-      that: ansible_play_hosts_all|length < groups.all|length
-      fail_msg: '[ERROR] All hosts not allowed.'
-    run_once: true
 
-  - name: Update current centos7 packages
-    ansible.builtin.yum: 
-      name: '*'
-      state: latest
-    register: cent_update
+    - name: quick check if all hosts was specified with no limit
+      ansible.builtin.assert:
+        that: ansible_play_hosts_all|length < groups.all|length
+        fail_msg: '[ERROR] All hosts not allowed.'
+      run_once: true
 
-  - name: Reboot if updates were made
-    ansible.builtin.reboot:
-      reboot_timeout: 3600
-    when: cent_update.changed
+    - name: Update current centos7 packages
+      ansible.builtin.yum:
+        name: '*'
+        state: latest
+      register: cent_update
 
-  - name: Grab current os version
-    ansible.builtin.shell: cat /etc/os-release | grep PRETTY_NAME
-    register: ver_pre
+    - name: Reboot if updates were made
+      ansible.builtin.reboot:
+        reboot_timeout: 3600
+      when: cent_update.changed
 
-#    ansible.builtin.shell: yum install -y http://repo.almalinux.org/elevate/elevate-release-latest-el$(rpm --eval %rhel).noarch.rpm
-  - name: Install elevate
-    ansible.builtin.yum:
-      name: http://repo.almalinux.org/elevate/elevate-release-latest-el7.noarch.rpm
-      state: latest
+    - name: Grab current os version
+      ansible.builtin.shell: cat /etc/os-release | grep PRETTY_NAME
+      register: ver_pre
 
-  - name: Install leap packages for general and rocky
-    ansible.builtin.yum:
-      name:
-        - leapp-upgrade
-        - leapp-data-rocky
-      state: latest
+    # Everything you need to do before starting the upgrade
+    - name: Manage custom tasks if existing
+      include_tasks: before_upgrade.yml
 
-  - name: run the leapp preupgrade
-    ansible.builtin.shell: leapp preupgrade
-    register: leapp_preupgrade
-    failed_when: '"END OF REPORT" not in leapp_preupgrade.stdout'
-    
-  - name: Build fix command list based on preupgrade file recommendations
-    ansible.builtin.shell: cat /var/log/leapp/leapp-report.txt | grep -F [command] | awk '{$1= ""; print $0}'
-    register: fix_commands
+    # ansible.builtin.shell: yum install -y http://repo.almalinux.org/elevate/elevate-release-latest-el$(rpm --eval %rhel).noarch.rpm
+    - name: Install elevate
+      ansible.builtin.yum:
+        name: http://repo.almalinux.org/elevate/elevate-release-latest-el7.noarch.rpm
+        state: latest
 
-  - name: Run standard preupgrade fixes
-    ansible.builtin.shell: "{{ item }}"
-    loop: 
-      - rmmod pata_acpi
-      - echo PermitRootLogin yes | tee -a /etc/ssh/sshd_config
-#      - leapp answer --section remove_pam_pkcs11_module_check.confirm=True
+    - name: Install leap packages for general and rocky
+      ansible.builtin.yum:
+        name:
+          - leapp-upgrade
+          - leapp-data-rocky
+        state: latest
 
-  - name: Run gathered preupgrade fixes
-    ansible.builtin.shell: "{{ item }}"
-    loop: "{{ fix_commands.stdout_lines }}"
+    - name: run the leapp preupgrade
+      ansible.builtin.shell: leapp preupgrade
+      register: leapp_preupgrade
+      failed_when: '"END OF REPORT" not in leapp_preupgrade.stdout'
 
-  - name: Run the leapp upgrade
-    ansible.builtin.shell: leapp upgrade
+    - name: Build fix command list based on preupgrade file recommendations
+      ansible.builtin.shell: cat /var/log/leapp/leapp-report.txt | grep -F [command] | awk '{$1= ""; print $0}'
+      register: fix_commands
 
-  - name: Reboot to complete upgrade
-    ansible.builtin.reboot:
-      reboot_timeout: 1200
+    - name: Run standard preupgrade fixes
+      ansible.builtin.shell: "{{ item }}"
+      loop:
+        - rmmod pata_acpi
+        - echo PermitRootLogin yes | tee -a /etc/ssh/sshd_config
+        # - leapp answer --section remove_pam_pkcs11_module_check.confirm=True
 
-  - name: set new python interpreter
-    ansible.builtin.set_fact:
-      ansible_python_interpreter: /usr/bin/python3
-    
-  - name: Grab current os version
-    ansible.builtin.shell: cat /etc/os-release | grep PRETTY_NAME
-    register: ver_post
+    - name: Run gathered preupgrade fixes
+      ansible.builtin.shell: "{{ item }}"
+      loop: "{{ fix_commands.stdout_lines }}"
 
-  - name: Display before and after versions
-    ansible.builtin.debug:
-      msg: "Version before {{ ver_pre.stdout | regex_replace('PRETTY_NAME=','')}}.  Version after {{ ver_post.stdout | regex_replace('PRETTY_NAME=','')}}."
+    - name: Run the leapp upgrade
+      ansible.builtin.shell: leapp upgrade
+
+    - name: Reboot to complete upgrade
+      ansible.builtin.reboot:
+        reboot_timeout: 1200
+
+    - name: set new python interpreter
+      ansible.builtin.set_fact:
+        ansible_python_interpreter: /usr/bin/python3
+
+    - name: Grab current os version
+      ansible.builtin.shell: cat /etc/os-release | grep PRETTY_NAME
+      register: ver_post
+
+    - name: Display before and after versions
+      ansible.builtin.debug:
+        msg: "Version before {{ ver_pre.stdout | regex_replace('PRETTY_NAME=','')}}.  Version after {{ ver_post.stdout | regex_replace('PRETTY_NAME=','')}}."
+
+    # Everything you need to do before starting the upgrade
+    - name: Manage custom tasks if existing
+      include_tasks: after_upgrade.yml

--- a/centos7-to-rocky-elevate.yml
+++ b/centos7-to-rocky-elevate.yml
@@ -45,6 +45,10 @@
           - leapp-data-rocky
         state: latest
 
+    # Everything you need to do before starting the upgrade
+    - name: Manage custom tasks if existing
+      include_tasks: after_leapp_install.yml
+
     - name: run the leapp preupgrade
       ansible.builtin.shell: leapp preupgrade
       register: leapp_preupgrade


### PR DESCRIPTION
Hi Greg,

I suggest this short code to react before or after an update.

You can easily set up custom actions, such as sending messages, deleting packages, etc., by creating files in the custom_tasks folder: 
- after_upgrade_custom_tasks.yml (task run before upgrade for all servers)
- before_upgrade_custom_tasks.yml (task run after upgrade for all servers)
or
- after_upgrade_{{ inventory_hostname_short }}_custom_tasks.yml
- before_upgrade_{{ inventory_hostname_short }}_custom_tasks.yml

In my case, I like to send a mattermost message before starting (and at the end) + I need to uninstall some packages (python dependencies that make fail the process).

I also make the linter succeed.

Regards